### PR TITLE
rimosse macro in favore di metodi

### DIFF
--- a/include/sensors/ball.h
+++ b/include/sensors/ball.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#define is_ball_close(distance) (distance > 350)
-#define is_ball_far(distance) (distance < 300)
 
 class Ball {
 private:
@@ -15,4 +13,6 @@ public:
     Ball();
     void read();
     void test();
+    bool is_close();
+    
 };

--- a/src/behavior/keeper.cpp
+++ b/src/behavior/keeper.cpp
@@ -22,7 +22,7 @@ void keeper() {
         break;
 
     case DEFEND:
-        if (ball->seen and ((is_ball_close(ball->distance) and (ball->absolute_angle < 30 or ball->absolute_angle > 330)) or ball_presence->is_in_mouth)) {
+        if (ball->seen and ((ball->is_close() and (ball->absolute_angle < 30 or ball->absolute_angle > 330)) or ball_presence->is_in_mouth)) {
             game_state = PARRY;
             start_time = millis();
         } else if (millis() - start_time >= IDLE_TIME) {
@@ -36,7 +36,7 @@ void keeper() {
 
     case PARRY:
         if (
-            !is_ball_close(ball->distance) or // Ball far
+            !ball->is_close() or // Ball far
             millis() - start_time >= SAVE_TIME or // Enough time passed
             (ball->absolute_angle > 90 and ball->absolute_angle < 270) or // Ball behind
             (millis() - start_time >= 100 and lines->status) // Seen lines after 100ms

--- a/src/behavior/striker.cpp
+++ b/src/behavior/striker.cpp
@@ -111,7 +111,7 @@ void attack() {
     // DIR e SPEED
     driver->speed = GAME_SPEED;
 
-    if (!is_ball_close(ball->distance)) driver->dir = ball->relative_angle;
+    if (!ball->is_close()) driver->dir = ball->relative_angle;
 
     else if (ball->relative_angle < 30)  driver->dir = ball->relative_angle * 2;
     else if (ball->relative_angle > 330) driver->dir = 360 - ((360 - ball->relative_angle) * 2);
@@ -147,7 +147,7 @@ void attack() {
     ) kicker->kick();
 
     // ROLLER
-    if (ball->relative_angle < 30 or ball->relative_angle > 330 or is_ball_close(ball->distance)) roller->on();
+    if (ball->relative_angle < 30 or ball->relative_angle > 330 or ball->is_close()) roller->on();
     else roller->off();
     #endif
 }

--- a/src/sensors/ball.cpp
+++ b/src/sensors/ball.cpp
@@ -51,3 +51,7 @@ void Ball::test() {
     driver->dy = 0;
     driver->orient = 0;
 }
+
+bool Ball::is_close() {
+     return ( distance > 350 );
+}


### PR DESCRIPTION
Perché usare le macro con parametri ?
non siamo negli anni '70 i compilatori sono in grado di fare ottimizzazioni... 
In particolare PlatformIO lancia il compilatore con l'opzione di ottimizzazione -Os 

<img width="743" height="172" alt="image" src="https://github.com/user-attachments/assets/4fc40713-7cfa-460e-98af-d21314581c48" />

Se non credi che con questa ottimizzazione l'uso delle macro è completamente inutile guarda qui:

[godbolt](https://godbolt.org/#z:OYLghAFBqd5TKALEBjA9gEwKYFFMCWALugE4A0BIEAZgQDbYB2AhgLbYgDkAjF%2BTXRMiAZVQtGIHgBYBQogFUAztgAKAD24AGfgCsp5eiyahUAUgBMAIUtXyKxqiIEh1ZpgDC6egFc2TKQBOcncAGQImbAA5PwAjbFIpLXIAB3QlYhcmL19/INT0zKFwyJi2eMSeZIdsJyyRIhZSIhy/AJ5gmrqhBqaiEui4hKT7RubWvI7RvoGyiqSASnt0H1JUTi4Aek2AagAVAE8U7B2DldIdjBwdpATsch2yHfp0Fkwd4x3sdXYUxgA6MxaACCQNBFgAzBFUL5rmYIR4XEoiKRsOx4bgwT4MiYdqwOEoUix1jtkZh4TYQTCWEolDsrBJ6DszAB2SnAlI%2BWL0AioEBgsE7IU7CJEHaEZHGdasqxaVkAEQpO229IIwGACXFBElTBJ8MVENwlxeKgusUZguFDPo9AgCwplqFsXQ3hFSgA%2BjD0tg7TLUURVkwtTq9YadhCAKxyiFWZksxUg4U7ABu6AI7xURHdmAgIuEePtbIljV12H1TAd8YFIIVDprINFOzYLAivrZ1eBSetTPNNrrneFjaD/aTqAizMNGLxI%2BFvfo/0z2YgTHtMcdlxWYvhHm3Ozn/21npNPtX7IF8a4S3o3Aj/ACXB05HQ3B31lspPOeshfHIRG0l6WABrEALAjf4oxZCEIS0aQtB4CwADYLC0AAOCNDG4aQ73/J9uH4JQQGSP8H0vcg4FgFAMDYFIGASShqComjGESYAeAjCwBAYIgEgIiBYhw2IIiaA5uB/QTWFIA4AHlYl0WpiJ/KiOGEKSmHoESSPIHBYh8YAPEZAjeH4HBmxMSRNMIVE6mTbBDMfb5ah8bjRP4UVsGvTSeViUhhK8HAcJRAg2Bc8gbNIZ0VHlbBTOAHkTH/JYaCMYAlAANQIbAAHcpOOe8f0EYQxAkTgZDkYRlDUTRNP0HhDGMUxbFsQwCFiAjICWdAUmcIRDIAWikpR%2BHQMLSHTWz4CWLpuoCCB3AmdoQiYTBZiGSoCgyab5oMNINqyFbymGWqpvqMYWm8NoDGOnpTv2%2BYjtOrb7pmCJBgOypJs/EqrxvbDNOfLgdnUFCEN6hDpB2YBUFQHY2P%2BCwdggfBiCeSwIR4BZ%2BGInQFiAkCIXAhCWRZFCtAsFlAkgiEKZZDCuCw8hgqqZJ70ff78MI38ErIxAIEo9BqNoigqAgRjBZAVj2M4%2BhuNIXj%2BM08ThJCxXJJkuSnBCpTmCIVT1Jw7TdP0m1DJ/Ez6vMx9LPkggbLs/gHNQJyNh/NyPMfLyfMkvyNkfQLgqM0KEgi7AopiuLQBIxLkrSjLstykKCtEcRJFKxOKo0HD9A4ox4vMN9rGa1qJqfLqsj6gahpGsa2rtex3Ot1xZqWx7FuWl65kO9aimyc7Ji76bbs7q6mF6cZe4W4fR/6dvVsuh7x7n57Sln9HllWdYQO%2Brhb3IFmhu4QHgdB8HIeh2H4cRwgSAuVGLAxznI6WW43mGWvgMQ/4WQQwIEKprQWS0OxHgKFAiyA8vTPeuEuDsyIlzciyA0BYDwFfMg9FaC0XxM7fgiciop1kGnFQGdqogTqrnRqBdh5uGbgvFCrdB6VAQv3LIW1aE7W7vQqQjDJ7z1yAEWh3Cl6vTulwnhF1%2BE3Rnm9ThH114bFRtCWEJxtxIhRGiNgGIsQ4mAHidgtkiQkjJP2AUkIcB0EiKSbAWYcyPFkg8IMCwbG6H%2BMWKUZYITygrDWEx2AzEnEPF6FQEB0CyR2A44JTiXGlgnEaSMWhmT1mBNSWk9JGRxnZJybkvJ%2BSJkHPmSJ0o2RyirDGZUuwrBqg1BcfJSj3FTgCZqOc65uy%2BjXDWYpZ4Gz5mbK2QsHSBxCm7HuC0rT%2Bl5jFMOEZo5xwaLDBWSZwpFw5jnLvU864MBOQnDuBECN/HHj4oyHGE4%2BkKlIh5HekD/qvhsNYD8sjmSQgsJjBKuMLDSH%2BGxdiUZXkoWkChZCvzaYQJwmzewHMsYAVpo8hmIAwb/DQihFkEYAFIRkAhEBu9gV4Qftjbm8BeYgEIDQGgaCcHJxKvg%2BQ6cqruyQARWq9BaWEpoEQI4nBkgMpUOoFELBOrTSxaQWlJCBVKCZSy44HNhXfG5byrIeEt7nMxVweUBAiU7HSllTUQMQZgwhlDGGYF4b9TpMmOkWrj66rPganYRqnmP3IM/HAiRa7gP4MFSM7zpDwWkBYQIEJiYRjRqVC5WKCKwLtR5CEv1WZYvBTjQOstZXSCAA)

A sinistra il codice con metodi che ad un programmatore anni '70 sembrerebbe generare un lungo e poco prestante codice per via delle chiamate (call ) con a fianco la traduzione in assembly,

A destra il codice con macro che ad un programmatore anni '70 sembrerebbe smarter e clever a fianco la sua traduzione in assembly 

In basso le differenze : **NESSUNA !!!!**  

 **Ma usare le macro significa non avere il controllo sui tipi, peggiore leggibilità, difficle controllo dello spazio dei nomi e fuoriero di bug difficili a trovare** 
 
La macro  definita è un po' diversa da quelle delle repo perché comunque un po' di semantica nella sua espansione il compilatore la fa e quindi senza specificare obj non capirebbe chi è distance ....

Infine ma non per ultimo :
Se proprio uno non si fida ancora può "suggerire" al compilatore di creare metodi inline (come fossero macro) per mezzo della keyword `inline` 